### PR TITLE
feat: Add vim-scala plugin

### DIFF
--- a/config/nvim/lua/user/plugins.lua
+++ b/config/nvim/lua/user/plugins.lua
@@ -111,6 +111,7 @@ return packer.startup(function(use)
   use "williamboman/nvim-lsp-installer" -- wrapper around nvim-lspconfig for easy installation
   use "kosayoda/nvim-lightbulb" -- lightbulb for code actions
   use({'scalameta/nvim-metals', requires = { "nvim-lua/plenary.nvim" }})
+  use "derekwyatt/vim-scala" -- only really using the https://github.com/derekwyatt/vim-scala#sorting-of-import-statements
   
   -- cmp plugins
   --------------

--- a/config/nvim/lua/user/plugins/lsp.lua
+++ b/config/nvim/lua/user/plugins/lsp.lua
@@ -73,6 +73,7 @@ wk.register({
   l = {
 	  name = "LSP",
 	  f = { "<cmd>lua vim.lsp.buf.formatting()<CR>", "Format" },
+	  s = { "<cmd>SortScalaImports<CR>", "Sort Imports" },
 	  a = { "<cmd>lua vim.lsp.buf.code_action()<CR>", "Actions" },
 	  d = { "<cmd>lua vim.diagnostic.setloclist()<CR>", "Diagnostics" },
 	  r = { "<cmd>lua vim.lsp.buf.rename()<CR>", "Rename Variable" },


### PR DESCRIPTION
(mainly just for sorting imports)

I liked this [vim-scala](https://github.com/derekwyatt/vim-scala) plugin from my go at using SpaceVim, and I see hey have it included [here](https://github.com/SpaceVim/SpaceVim/blob/caf1d8428aa0e210888e7d2d197594388beebf12/autoload/SpaceVim/layers/lang/scala.vim#L258-L262)...

but I'm not quite sure where/how to define the "which key" mapping for it in my lunarvim config.
(FYI I'd like to give it the mapping `"[space] l s"` so it can sit next to the `"[space] l f"` mapping for the `Format` command that autoformats the code.)

Can you help me finish this PR to do that @nwaywood? 🙏 

